### PR TITLE
Use random IV when creating a cipher using `aes-256-ctr`

### DIFF
--- a/lib/kms.js
+++ b/lib/kms.js
@@ -23,26 +23,43 @@ const create = (kms) => {
               .then(res => res.Plaintext);
   };
 
-  const algorithm = 'aes-256-ctr';
+  const ALGORITHM = 'aes-256-ctr';
+  const IV_LENGTH = 16; // For AES, this is 16
+  const DELIMITER = '$';
 
   const encryptWithPassword = (data, password) => {
     assert.buffer(password, 'Must provide password');
     assert.string(data, 'Must provide data to encrypt');
 
-    const cipher = crypto.createCipher(algorithm, password);
-    let crypted = cipher.update(data, 'utf8', 'hex');
-    crypted += cipher.final('hex');
-    return crypted;
+    const iv = crypto.randomBytes(IV_LENGTH);
+    const cipher = crypto.createCipheriv(ALGORITHM, password, iv);
+    let encrypted = cipher.update(data, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    return iv.toString('hex') + DELIMITER + encrypted;
   };
 
   const decryptWithPassword = (data, password) => {
     assert.buffer(password, 'Must provide password');
     assert.string(data, 'Must provide encrypted data for decryption');
 
-    const decipher = crypto.createDecipher(algorithm, password);
-    let dec = decipher.update(data, 'hex', 'utf8');
-    dec += decipher.final('utf8');
-    return dec;
+    const hasIV = data.includes(DELIMITER);
+
+    let decipher;
+    if (hasIV) {
+      const parts = data.split(DELIMITER);
+      const iv = new Buffer(parts.shift(), 'hex');
+      let encryptedPart = new Buffer(parts.join(DELIMITER), 'hex');
+      decipher = crypto.createDecipheriv(ALGORITHM, password, iv);
+      let dec = decipher.update(encryptedPart, 'hex', 'utf8');
+      dec += decipher.final('utf8');
+      return dec;
+    } else {
+      decipher = crypto.createDecipher(ALGORITHM, password); // deprecated
+      let dec = decipher.update(data, 'hex', 'utf8');
+      dec += decipher.final('utf8');
+      return dec;
+    }
   };
 
   const generateDataKey = (keyId, options) => {

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -24,7 +24,8 @@ const create = (kms) => {
   };
 
   const ALGORITHM = 'aes-256-ctr';
-  const IV_LENGTH = 16; // For AES, this is 16
+  // For AES, this is 16
+  const IV_LENGTH = 16;
   const DELIMITER = '$';
 
   const encryptWithPassword = (data, password) => {
@@ -55,7 +56,8 @@ const create = (kms) => {
       dec += decipher.final('utf8');
       return dec;
     } else {
-      decipher = crypto.createDecipher(ALGORITHM, password); // deprecated
+      // deprecated
+      decipher = crypto.createDecipher(ALGORITHM, password);
       let dec = decipher.update(data, 'hex', 'utf8');
       dec += decipher.final('utf8');
       return dec;


### PR DESCRIPTION
Switch encryption and decryption to use a randomly generated IV for every operation which is then stored alongside the encrypted text in the `.env` file. 

Also make sure we can decrypt old encrypted values that did not utilize IVs

closes #3 