### PR TITLE
fix: export values having space

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -171,7 +171,7 @@ const create = (client, fs) => {
                 });
 
                 return decrypted.map(pair => {
-                  return `export ${pair.key}=${pair.value};echo "Decrypted ${pair.key}";`;
+                  return `export ${pair.key}="${pair.value}";echo "Decrypted ${pair.key}";`;
                 }).join('\n');
               });
   };


### PR DESCRIPTION
quotes are required in order to
export values containing spaces

example
export MY_KEY=foo bar - only exports first word
export MY_KEY="foo bar"